### PR TITLE
Add curl to the installed apt packages

### DIFF
--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -138,7 +138,7 @@ bootstrap_environment(){
 
     # Install jq, openssl, xxd
     sudo apt-get install -y jq openssl xxd >> $LOG_FILE 2>&1
-    errchk $? "sudo apt-get install -y jq openssl xxd >> $LOG_FILE 2>&1"
+    errchk $? "sudo apt-get install -y curl jq openssl xxd >> $LOG_FILE 2>&1"
 
     # Install microk8s classic via snap package
     sudo snap install microk8s --classic >> $LOG_FILE 2>&1


### PR DESCRIPTION
#4 

Added curl to apt package installation. Script bombed at the VERY end because user installed base Ubuntu image without curl by default (guessing base Ubuntu instead of server)