### PR TITLE
Hotfix to handle expired certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An issue with microk8s (not Dragonchain or our software) has been discovered tha
 
 If you run into this problem, SSH into your node and run the following command:
 
-```sudo wget -O - https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/hotfix-certificates/update_certificates.sh | bash```
+```wget https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/hotfix-certificates/update_certificates.sh && chmod u+x update_certificates.sh && sudo ./update_certificates.sh```
     
 If, after running, you don't see all "1/1" and "Running" for the status of your pods, please try running the following command to check the status again:
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -256,8 +256,9 @@ bootstrap_environment(){
     errchk $? "sudo apt-get install -y ufw curl jq openssl xxd snapd >> $LOG_FILE 2>&1"
 
     # Install microk8s classic via snap package
-    sudo snap install microk8s --channel=1.18/stable --classic >> $LOG_FILE 2>&1
-    errchk $? "sudo snap install microk8s --channel=1.18/stable --classic >> $LOG_FILE 2>&1"
+    # TODO - Revert to stable when refresh-certs is merged
+    sudo snap install microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1
+    errchk $? "sudo snap install microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1"
 
     # Because we have microk8s, we need to alias kubectl
     sudo snap alias microk8s.kubectl kubectl >> $LOG_FILE 2>&1

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -27,6 +27,6 @@ errchk $? "Microk8s update"
 sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
 errchk $? "Certificate refresh"
 
-printf "\nIf you see no errors above, you should be up-to-date. Check in Telegram if you still have trouble!\n"
+printf "\n\e[92mIf you see no errors above, you should be up-to-date. Check in Telegram if you still have trouble!\e[0m\n"
 
 exit 0

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -44,14 +44,14 @@ printf "\nRefreshing certificates...\n"
 sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
 errchk $? "Certificate refresh"
 
-sleep 5
+sleep 15
 
 # Restart microk8s for some damned reason
 printf "\nRestarting microk8s...\n"
 sudo microk8s.stop >> $LOG_FILE 2>&1
 errchk $? "Stopping microk8s"
 
-sleep 5
+sleep 15
 
 sudo microk8s.start >> $LOG_FILE 2>&1
 errchk $? "Starting microk8s"

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -19,6 +19,20 @@ errchk() {
 
 printf "\nUpdating microk8s and refreshing certificates...\n"
 
+# Create the installer directory
+if [ ! -e $DRAGONCHAIN_INSTALLER_DIR ]; then
+    mkdir -p $DRAGONCHAIN_INSTALLER_DIR
+    errchk $? "mkdir -p $DRAGONCHAIN_INSTALLER_DIR"
+fi
+
+# Generate logfiles & rotate as appropriate
+if [ ! -e $LOG_FILE ]; then
+    touch $LOG_FILE >/dev/null 2>&1
+    errchk $? "touch $LOG_FILE >/dev/null 2>&1"
+else
+    savelog -t -c 5 -l -p -n -q $LOG_FILE
+fi
+
 # Install microk8s classic via snap package
 # TODO - Replace with stable after microk8s.refresh-certs is stabilized
 sudo snap refresh microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-LOG_FILE=dragonchain_certificate_update.log
+DRAGONCHAIN_INSTALLER_DIR=~/.dragonchain-installer
+LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_certificate_update.log
 
 ##########################################################################
 ## Function errchk

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+LOG_FILE=dragonchain_certificate_update.log
+
+##########################################################################
+## Function errchk
+## $1 should be $? from the command being checked
+## $2 should be the command executed
+## When passing $2, do not forget to escape any ""
+errchk() {
+    if [ "$1" -ne 0 ] ; then
+        printf "\nERROR: RC=%s; CMD=%s\n" "$1" "$2" >> $LOG_FILE
+        printf "\nERROR: RC=%s; CMD=%s\n" "$1" "$2"
+        exit "$1"
+    fi
+    printf "\nPASS: %s\n" "$2" >> $LOG_FILE
+}
+
+printf "\nUpdating microk8s and refreshing certificates...\n"
+
+# Install microk8s classic via snap package
+# TODO - Replace with stable after microk8s.refresh-certs is stabilized
+sudo snap refresh microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1
+errchk $? "Microk8s update"
+
+# Refresh certificates just in case
+sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
+errchk $? "Certificate refresh"
+
+printf "\nIf you see no errors above, you should be up-to-date. Check in Telegram if you still have trouble!\n"
+
+exit 0

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -35,16 +35,19 @@ fi
 
 # Install microk8s classic via snap package
 # TODO - Replace with stable after microk8s.refresh-certs is stabilized
+printf "\nUpdating microk8s...\n"
 sudo snap refresh microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1
 errchk $? "Microk8s update"
 
 # Refresh certificates just in case
+printf "\nRefreshing certificates...\n"
 sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
 errchk $? "Certificate refresh"
 
 sleep 15
 
 # Restart microk8s for some damned reason
+printf "\nRestarting microk8s...\n"
 sudo microk8s.stop >> $LOG_FILE 2>&1
 errchk $? "Stopping microk8s"
 
@@ -55,6 +58,7 @@ errchk $? "Starting microk8s"
 
 sleep 30
 
+printf "\nGetting pod status:\n"
 sudo kubectl get pods -n dragonchain
 
 printf "\n\e[92mIf you see no errors and all pods show status of '1/1' above, you should be up-to-date. Check in Telegram if you still have trouble!\e[0m\n"

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -44,19 +44,19 @@ printf "\nRefreshing certificates...\n"
 sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
 errchk $? "Certificate refresh"
 
-sleep 15
+sleep 5
 
 # Restart microk8s for some damned reason
 printf "\nRestarting microk8s...\n"
 sudo microk8s.stop >> $LOG_FILE 2>&1
 errchk $? "Stopping microk8s"
 
-sleep 15
+sleep 5
 
 sudo microk8s.start >> $LOG_FILE 2>&1
 errchk $? "Starting microk8s"
 
-sleep 30
+sleep 60
 
 printf "\nGetting pod status:\n"
 sudo kubectl get pods -n dragonchain

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -61,6 +61,6 @@ sleep 30
 printf "\nGetting pod status:\n"
 sudo kubectl get pods -n dragonchain
 
-printf "\n\e[92mIf you see no errors and all pods show status of '1/1' above, you should be up-to-date. Check in Telegram if you still have trouble!\e[0m\n"
+printf "\n\e[92mIf you see no errors and all pods show '1/1' and 'Running' above, you should be up-to-date. Check in Telegram if you still have trouble!\e[0m\n"
 
 exit 0

--- a/update_certificates.sh
+++ b/update_certificates.sh
@@ -42,6 +42,21 @@ errchk $? "Microk8s update"
 sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
 errchk $? "Certificate refresh"
 
-printf "\n\e[92mIf you see no errors above, you should be up-to-date. Check in Telegram if you still have trouble!\e[0m\n"
+sleep 15
+
+# Restart microk8s for some damned reason
+sudo microk8s.stop >> $LOG_FILE 2>&1
+errchk $? "Stopping microk8s"
+
+sleep 15
+
+sudo microk8s.start >> $LOG_FILE 2>&1
+errchk $? "Starting microk8s"
+
+sleep 30
+
+sudo kubectl get pods -n dragonchain
+
+printf "\n\e[92mIf you see no errors and all pods show status of '1/1' above, you should be up-to-date. Check in Telegram if you still have trouble!\e[0m\n"
 
 exit 0

--- a/upgrade_dragonchain_uvn.sh
+++ b/upgrade_dragonchain_uvn.sh
@@ -259,8 +259,13 @@ patch_server_current() {
 bootstrap_environment(){
    
     # Install microk8s classic via snap package
-    sudo snap refresh microk8s --channel=1.18/stable --classic >> $LOG_FILE 2>&1
-    errchk $? "sudo snap refresh microk8s --channel=1.18/stable --classic >> $LOG_FILE 2>&1"
+    # TODO - Replace with stable after microk8s.refresh-certs is stabilized
+    sudo snap refresh microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1
+    errchk $? "sudo snap refresh microk8s --channel=1.18/beta --classic >> $LOG_FILE 2>&1"
+
+    # Refresh certificates just in case
+    sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1
+    errchk $? "sudo microk8s.refresh-certs -i >> $LOG_FILE 2>&1"
 
     # Wait for system to stabilize and avoid race conditions
     sleep 30


### PR DESCRIPTION
Microk8s has some kind of global issue with expiring certificates.

This fix updates to beta channel of microk8s in order to enable the `microk8s.refresh-certs` command, then executes that command in the upgrade script.

Also added a separate, dedicated (and hopefully temporary) script to JUST update microk8s and refresh certificates.