### PR TITLE
Minor OS level tweaks

### DIFF
--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -226,18 +226,6 @@ request_user_defined_values() {
 
 }
 
-
-##########################################################################
-## Function patch_server_current
-patch_server_current() {
-    #Patch our system current [stable]
-    sudo apt-get update >> $LOG_FILE 2>&1
-    errchk $? "sudo apt-get update >> $LOG_FILE 2>&1"
-
-#    sudo apt-get upgrade -y >> $LOG_FILE 2>&1
-#    errchk $? "sudo apt-get upgrade -y >> $LOG_FILE 2>&1"
-}
-
 ##########################################################################
 ## Function bootstrap_environment
 bootstrap_environment(){
@@ -502,10 +490,6 @@ preflight_check
 
 #load config values or gather from user
 set_config_values
-
-#patch system current
-printf "\nUpdating (patching) host OS current...\n"
-patch_server_current
 
 #install necessary software, set tunables
 printf "\nInstalling required software and setting Dragonchain UVN system configuration...\n"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -452,26 +452,6 @@ check_matchmaking_status() {
     fi
 }
 
-offer_apt_upgrade() {
-
-    echo -e "\e[93mIt is HIGHLY recommended that you run 'sudo apt-get upgrade -y' at this time to update your operating system.\e[0m"
-
-    local ANSWER=""
-    while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]
-    do
-        echo -e "Run the upgrade command now? [yes or no]"
-        read ANSWER
-        echo
-    done
-
-    if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]
-    then
-        # User wants fresh values
-        sudo apt-get upgrade -y
-        errchk $? "sudo apt-get upgrade -y"
-    fi
-}
-
 ## Main()
 
 #check for required commands, setup logging

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -442,9 +442,6 @@ check_matchmaking_status() {
 
         echo -e "\e[92mYOUR DRAGONCHAIN NODE IS ONLINE AND REGISTERED WITH THE MATCHMAKING API! HAPPY NODING!\e[0m"
 
-        #duck Prevent offering upgrade until latest kubernetes/helm issues are resolved
-        #offer_apt_upgrade
-
     else
         #Boo!
         echo -e "\e[31mYOUR DRAGONCHAIN NODE IS ONLINE BUT THE MATCHMAKING API RETURNED AN ERROR. PLEASE SEE BELOW AND REQUEST HELP IN DRAGONCHAIN TELEGRAM\e[0m"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -91,16 +91,6 @@ preflight_check() {
         printf "\nERROR: Sudo configuration may not be ideal for this setup. Exiting.\n"
         exit 1
     fi
-
-    # assume user executing is ubuntu with sudo privs
-    if [ -e ./dragonchain-setup ]; then
-        rm -r ./dragonchain-setup >/dev/null 2>&1
-        mkdir ./dragonchain-setup
-        errchk $? "mkdir ./dragonchain-setup"
-    else
-        mkdir ./dragonchain-setup
-        errchk $? "mkdir ./dragonchain-setup"
-    fi
 }
 
 ##########################################################################

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -436,6 +436,11 @@ check_matchmaking_status() {
     if [ $SUCCESS_CHECK -eq 1 ]
     then
         #SUCCESS!
+
+        echo "Your HMAC (aka Access) Key Details are as follows (please save for future use):" >> $SECURE_LOG_FILE
+        echo "ID: $HMAC_ID" >> $SECURE_LOG_FILE
+        echo "Key: $HMAC_KEY" >> $SECURE_LOG_FILE
+
         echo "Your HMAC (aka Access) Key Details are as follows (please save for future use):"
         echo "ID: $HMAC_ID"
         echo "Key: $HMAC_KEY"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -43,7 +43,7 @@ trim() {
     # remove leading whitespace characters
     var="${var#"${var%%[![:space:]]*}"}"
     # remove trailing whitespace characters
-    var="${var%"${var##*[![:space:]]}"}"   
+    var="${var%"${var##*[![:space:]]}"}"
     echo -n "$var"
 }
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -230,6 +230,11 @@ bootstrap_environment(){
     errchk $? "sudo sysctl -w vm.max_map_count=262144 >> $LOG_FILE 2>&1"
 
     # Install jq, openssl, xxd
+
+    # Refresh available packages or install below may fail
+    sudo apt-get update >> $LOG_FILE 2>&1
+    errchk $? "sudo apt-get update >> $LOG_FILE 2>&1"
+
     sudo apt-get install -y ufw curl jq openssl xxd snapd >> $LOG_FILE 2>&1
     errchk $? "sudo apt-get install -y ufw curl jq openssl xxd snapd >> $LOG_FILE 2>&1"
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -229,12 +229,11 @@ bootstrap_environment(){
     sudo sysctl -w vm.max_map_count=262144 >> $LOG_FILE 2>&1
     errchk $? "sudo sysctl -w vm.max_map_count=262144 >> $LOG_FILE 2>&1"
 
-    # Install jq, openssl, xxd
-
     # Refresh available packages or install below may fail
     sudo apt-get update >> $LOG_FILE 2>&1
     errchk $? "sudo apt-get update >> $LOG_FILE 2>&1"
 
+    # Install jq, openssl, xxd
     sudo apt-get install -y ufw curl jq openssl xxd snapd >> $LOG_FILE 2>&1
     errchk $? "sudo apt-get install -y ufw curl jq openssl xxd snapd >> $LOG_FILE 2>&1"
 


### PR DESCRIPTION
Curious to your opinion on these small changes to the installer. To summarize:

- fix trailing spaces (trivial)
- Deprecate patch_server_current & offer_apt_upgrade
- Add logging for HMAC_ID and HMAC_KEY to "secure" log (not encryption offered)

I _REALLY_ hate to leave the apt update & apt upgrade out of the code because folks will (perhaps unknowingly) use out of date Operating Systems for DRGN UVN. However, it seems as more and more folks are using "budget" friendly VPS providers, the majority of these folks are running into issues with a simple OS update. Additionally, we deprecated the apt-upgrade functionality several months back. I think we have taken a huge step back for security and this would make OS Security (package/patch related) out of scope (OoS) for this effort.

Before merging, we should determine if this is the right step and if it makes sense to apply the same changes to the upgrade script.

In current form, this has been tested on a t2.small AWS Ubuntu 18.04 instance.

In related news, resetting microk8s is still broken. I will log an issue for it. 

