### PR TITLE
Multi-node Installer and Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # dragonchain-uvn-installer 
 
-This project enables "easy mode" setup and installation of a Dragonchain Level 2 Unmanaged Verification Node
+This project enables "easy mode" setup and installation of multiple Dragonchain Level 2 , 3 and 4 Unmanaged Verification Nodes
 
 ### Limitations:
 
 Currently, the following limitations are in place for this script to function:
 - Must be run on a Ubuntu linux installation (standard or server version)
     - Recommended server specs for the current Dragonchain release: 1 CPUs, 2GB RAM
+	- Raspberry Pi 2GB, 4GB and 8GB supported. The installer will detect the Raspberry Pi hardware and install with the required CPU limits
 
 ### NOTE: IF YOUR NODE GOES UNHEALTHY ALL OF A SUDDEN, FOLLOW THE NEXT INSTRUCTIONS:
 
-An issue with microk8s (not Dragonchain or our software) has been discovered that can cause nodes (especially those installed after approximately April 1st) to go into "unhealthy" status because they aren't able to process blocks.
+An issue with microk8s (not Dragonchain or our software) has been discovered that can cause nodes (especially those installed after approximately April 1st 2020) to go into "unhealthy" status because they aren't able to process blocks.
 
 If you run into this problem, SSH into your node and run the following command:
 
@@ -18,7 +19,7 @@ If you run into this problem, SSH into your node and run the following command:
     
 If, after running, you don't see all "1/1" and "Running" for the status of your pods, please try running the following command to check the status again:
 
-```sudo kubectl get pods -n dragonchain```
+```sudo watch kubectl get pods --all-namespaces```
 
 If you still don't see all "1/1" and "Running," check in Telegram for support.
 
@@ -26,7 +27,7 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 
 - Clone the repo or download the **install_dragonchain_uvn.sh** file
 
-    ```rm -f ./install_dragonchain_uvn.sh && wget https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/release-v3.2/install_dragonchain_uvn.sh```
+    ```rm -f ./install_dragonchain_uvn.sh && wget https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/release-v5.0/install_dragonchain_uvn.sh```
 
 
 - Make the script executable:
@@ -39,20 +40,19 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 
 ### To UPGRADE a Running Dragonchain Unmanaged Node:
 
-- Clone the repo or download the **upgrade_dragonchain_uvn.sh** file
+- Run the same script with sudo:
 
-    ```rm -f ./upgrade_dragonchain_uvn.sh && wget https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/release-v3.2/upgrade_dragonchain_uvn.sh```
+    ```sudo ./install_dragonchain_uvn.sh```
+
+- When the installer loads, it should detect pre-existing Dragonchain nodes. Choose option [u] to upgrade all installed Dragonchains.
 
 
-- Make the script executable:
+- To check the chart version number your Dragonchain nodes are running:
 
-    ```chmod u+x upgrade_dragonchain_uvn.sh```
-
-- Run the script with sudo:
-
-    ```sudo ./upgrade_dragonchain_uvn.sh```
+	```sudo helm list --all-namespaces```
 
 ### Coming features:
+
 - Support for pre-built config files for easy automatic deployment
 
 *Dragonchain-Community and this project are not affiliated with Dragonchain, Inc. or the Dragonchain Foundation*

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
     ```sudo ./install_dragonchain_uvn.sh```
 	
 
-- When the installer loads, it should detect pre-existing Dragonchain nodes. Choose option [u] to upgrade all installed Dragonchains.
+- When the installer loads, it should detect pre-existing Dragonchain nodes. Choose option [u] to upgrade all installed nodes.
 
 
 - To check the chart version number your Dragonchain nodes are running:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Terminate the watch with CTRL + C
 
 If you still don't see all "1/1" and "Running," check in Telegram for support.
 
+
 ### To INSTALL a New Dragonchain Unmanaged Node:
 
 - Clone the repo or download the **install_dragonchain_uvn.sh** file
@@ -40,6 +41,9 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 - Run the script with sudo:
 
     ```sudo ./install_dragonchain_uvn.sh```
+	
+- Additional ndoes can be installed by choosing option [yes] when prompted at the end of the initial node installation.
+
 
 ### To UPGRADE a Running Dragonchain Unmanaged Node:
 
@@ -53,6 +57,7 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 - To check the chart version number your Dragonchain nodes are running:
 
 	```sudo helm list --all-namespaces```
+
 
 ### Coming features:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, the following limitations are in place for this script to function:
 
 ### NOTE: IF YOUR NODE GOES UNHEALTHY ALL OF A SUDDEN, FOLLOW THE NEXT INSTRUCTIONS:
 
-An issue with microk8s (not Dragonchain or our software) has been discovered that can cause nodes (especially those installed after approximately April 1st 2020) to go into "unhealthy" status because they aren't able to process blocks.
+An issue with microk8s (not Dragonchain or our software) has been discovered that can cause nodes (especially those installed after approximately April 1st) to go into "unhealthy" status because they aren't able to process blocks.
 
 If you run into this problem, SSH into your node and run the following command:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project enables "easy mode" setup and installation of multiple Dragonchain 
 
 Currently, the following limitations are in place for this script to function:
 - Must be run on a Ubuntu linux installation (standard or server version)
-    - Recommended server specs for the current Dragonchain release: 1 CPUs, 2GB RAM
+    - Recommended server specs for the current Dragonchain release: 1 CPUs, 2GB RAM (more CPU and RAM may be required for additional nodes)
 	- Raspberry Pi 2GB, 4GB and 8GB supported. The installer will detect the Raspberry Pi hardware and install with the required CPU limits
 
 ### NOTE: IF YOUR NODE GOES UNHEALTHY ALL OF A SUDDEN, FOLLOW THE NEXT INSTRUCTIONS:

--- a/README.md
+++ b/README.md
@@ -42,14 +42,25 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 
     ```sudo ./install_dragonchain_uvn.sh```
 	
+	
 - Additional nodes can be installed by choosing option [yes] when prompted at the end of the initial node installation.
 
 
 ### To UPGRADE Running Dragonchain Unmanaged Node/s:
 
-- Run the same script with sudo:
+- Clone the repo or download the **install_dragonchain_uvn.sh** file
+
+    ```rm -f ./install_dragonchain_uvn.sh && wget https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/release-v5.0/install_dragonchain_uvn.sh```
+
+
+- Make the script executable:
+
+    ```chmod u+x install_dragonchain_uvn.sh```
+
+- Run the script with sudo:
 
     ```sudo ./install_dragonchain_uvn.sh```
+	
 
 - When the installer loads, it should detect pre-existing Dragonchain nodes. Choose option [u] to upgrade all installed Dragonchains.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 
     ```sudo ./install_dragonchain_uvn.sh```
 	
-- Additional ndoes can be installed by choosing option [yes] when prompted at the end of the initial node installation.
+- Additional nodes can be installed by choosing option [yes] when prompted at the end of the initial node installation.
 
 
 ### To UPGRADE a Running Dragonchain Unmanaged Node:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ If you run into this problem, SSH into your node and run the following command:
 
 ```wget https://raw.githubusercontent.com/Dragonchain-Community/dragonchain-uvn-installer/hotfix-certificates/update_certificates.sh && chmod u+x update_certificates.sh && sudo ./update_certificates.sh```
     
-If, after running, you don't see all "1/1" and "Running" for the status of your pods, please try running the following command to check the status again:
+If, after running, you don't see all "1/1" and "Running" for the status of your pods, please try running the following command to check the status continuously:
 
 ```sudo watch kubectl get pods --all-namespaces```
+
+Terminate the watch with CTRL + C
+
 
 If you still don't see all "1/1" and "Running," check in Telegram for support.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dragonchain-uvn-installer 
 
-This project enables "easy mode" setup and installation of multiple Dragonchain Level 2 , 3 and 4 Unmanaged Verification Nodes
+This project enables "easy mode" setup and installation of multiple Dragonchain Level 2-4 Unmanaged Verification Nodes
 
 ### Limitations:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Terminate the watch with CTRL + C
 If you still don't see all "1/1" and "Running," check in Telegram for support.
 
 
-### To INSTALL a New Dragonchain Unmanaged Node:
+### To INSTALL New Dragonchain Unmanaged Node/s:
 
 - Clone the repo or download the **install_dragonchain_uvn.sh** file
 
@@ -45,7 +45,7 @@ If you still don't see all "1/1" and "Running," check in Telegram for support.
 - Additional nodes can be installed by choosing option [yes] when prompted at the end of the initial node installation.
 
 
-### To UPGRADE a Running Dragonchain Unmanaged Node:
+### To UPGRADE Running Dragonchain Unmanaged Node/s:
 
 - Run the same script with sudo:
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -355,9 +355,9 @@ initialize_microk8s() {
 ##########################################################################
 ## Function check_existing_install
 check_existing_install() {
-    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -c $DRAGONCHAIN_INSTALLER_DIR)
+    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -w $DRAGONCHAIN_INSTALLER_DIR)
 
-    if [ $NAMESPACE_EXISTS -ge 1 ]; then
+    if [ $NAMESPACE_EXISTS ]; then
         echo -e "\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"
 
         local ANSWER=""

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -355,9 +355,9 @@ initialize_microk8s() {
 ##########################################################################
 ## Function check_existing_install
 check_existing_install() {
-    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -w $DRAGONCHAIN_INSTALLER_DIR)
+    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -w $DRAGONCHAIN_INSTALLER_DIR | grep -c $DRAGONCHAIN_INSTALLER_DIR)
 
-    if [ $NAMESPACE_EXISTS ]; then
+    if [ $NAMESPACE_EXISTS -ge 1 ]; then
         echo -e "\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"
 
         local ANSWER=""

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -217,7 +217,7 @@ request_user_defined_values() {
 
     #duck Moved node port firewall rule here in order to run bootstrap before this parameter is created
     sleep 2
-    sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp -w >>$LOG_FILE 2>&1
+    sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >> $LOG_FILE 2>&1"
     sleep 2
 
@@ -304,7 +304,7 @@ bootstrap_environment() {
     sleep 2
 
     sleep 2
-    sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
+    sudo ufw allow in on cni0 >>$LOG_FILE 2>&1 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
     sleep 2
 
@@ -620,7 +620,7 @@ offer_nodes_upgrade() {
     if [ $DC_PODS_EXIST -ge 1 ]; then
         local ANSWER=""
         while [[ "$ANSWER" != "i" && "$ANSWER" != "install" && "$ANSWER" != "u" && "$ANSWER" != "upgrade" ]]; do
-            echo -e "\n\n\e[93mPre-existing Dragonchain nodes have been detected.\e[0m"
+            echo -e "\n\e[93mPre-existing Dragonchain nodes have been detected.\e[0m"
             echo -e "\e[2mIf you would like to install a new node (including upgrading, repairing or deleting specific nodes), press \e[93m[i]\e[0m"
             echo -e "\e[2mIf you would like to upgrade ALL detected nodes to the latest version, press \e[93m[u]\e[0m"
             read ANSWER

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -276,7 +276,7 @@ bootstrap_environment() {
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
     #duck To stop ufw errors 'Could not load logging rules', disable logging 
-    sudo ufw ufw logging off >>$LOG_FILE 2>&1
+    sudo ufw logging off >>$LOG_FILE 2>&1
     errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
     sleep 5
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -53,6 +53,13 @@ prompt_node_name() {
 
     read -e DRAGONCHAIN_INSTALLER_DIR
 
+    local ANSWER=""
+    while [[ "$PI" != "y" && "$PI" != "yes" && "$PI" != "n" && "$PI" != "no" ]]; do
+        echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no]\e[0m"
+        read ANSWER
+        echo
+    done
+
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
 }
@@ -429,19 +436,11 @@ install_dragonchain() {
     sudo helm repo update >>$LOG_FILE 2>&1
     errchk $? "sudo helm repo update >> $LOG_FILE 2>&1"
 
-    local ANSWER=""
-    while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]; do
-        echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no].\e[0m"
-        read ANSWER
-        echo
-    done
-
-    if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]; then
+    if [[ "$PI" == "y" || "$PI" == "yes" ]]; then
         # User is running Raspberry Pi
         # Deploy Helm Chart
         #
-        # For Raspberry Pi installations, uncomment the last --set line and
-        # on the --set redis.storage.spec.storageClassName line above it, replace >> $LOG_FILE 2>&1 with \
+        # Set CPU limits 
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
         --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \
@@ -454,13 +453,13 @@ install_dragonchain() {
         --set redisearch.storage.spec.storageClassName="microk8s-hostpath" \
         --set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >>$LOG_FILE 2>&1
 
+        errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"
+
     else
 
         # User is not running Raspberry Pi
         # Deploy Helm Chart
         #
-        # For Raspberry Pi installations, uncomment the last --set line and
-        # on the --set redis.storage.spec.storageClassName line above it, replace >> $LOG_FILE 2>&1 with \
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
         --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \
@@ -471,8 +470,7 @@ install_dragonchain() {
         --set dragonchain.storage.spec.storageClassName="microk8s-hostpath" \
         --set redis.storage.spec.storageClassName="microk8s-hostpath" \
         --set redisearch.storage.spec.storageClassName="microk8s-hostpath" >>$LOG_FILE 2>&1
-        #--set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
-
+        
         errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"
 
     fi
@@ -556,7 +554,7 @@ check_matchmaking_status() {
 
         local ANSWER=""
         while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]; do
-            echo -e "\n\e[93mWould you like to install another Dragonchain node? [yes or no].\e[0m"
+            echo -e "\n\e[93mWould you like to install another Dragonchain node? [yes or no]\e[0m"
             read ANSWER
             echo
         done

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -493,6 +493,46 @@ check_matchmaking_status() {
         #duck Prevent offering upgrade until latest kubernetes/helm issues are resolved
         #offer_apt_upgrade
 
+        #offer to install another node or exit
+
+        local ANSWER=""
+        while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]; do
+            echo -e "\n\e[93mWould you like to install another Dragonchain node? [yes or no].\e[0m"
+            read ANSWER
+            echo
+        done
+
+        if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]; then
+
+        ## Prompt for Dragonchain node name
+        prompt_node_name
+
+        #load config values or gather from user
+        set_config_values
+
+        # check for previous installation (failed or successful) and offer reset if found
+        printf "\nChecking for previous installation...\n"
+        check_existing_install
+
+        # must gather node details from user or .config before generating chainsecrets
+        printf "\nGenerating chain secrets...\n"
+        generate_chainsecrets
+
+        printf "\nInstalling UVN Dragonchain - $DRAGONCHAIN_INSTALLER_DIR...\n"
+        install_dragonchain
+
+        check_kube_status
+
+        set_dragonchain_public_id
+
+        check_matchmaking_status
+
+        done
+
+        exit 0
+
+        fi
+    
     else
         #Boo!
         echo -e "\e[31mYOUR DRAGONCHAIN NODE '$DRAGONCHAIN_INSTALLER_DIR' IS ONLINE BUT THE MATCHMAKING API RETURNED AN ERROR. PLEASE SEE BELOW AND REQUEST HELP IN DRAGONCHAIN TELEGRAM\e[0m"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -394,7 +394,7 @@ check_existing_install() {
             echo -e "\nDeleting firewall configuration for '$DRAGONCHAIN_INSTALLER_DIR'..."
             sudo sudo ufw delete allow $DRAGONCHAIN_UVN_NODE_PORT/tcp
 
-            echo -e "\n\e[93mConfiguration data for '$DRAGONCHAIN_INSTALLER_DIR' has been deleted and the node has been terminated.\e[0m"
+            echo -e "\n\e[93mConfiguration data for '$DRAGONCHAIN_INSTALLER_DIR' has been deleted and the node has been removed.\e[0m"
             echo -e "\e[93mPlease rerun the installer to reconfigure this node.\e[0m"
 
             exit 0

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -273,39 +273,57 @@ bootstrap_environment() {
 
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
-    #duck To stop ufw errors 'Could not load logging rules', disable logging
+    #duck To stop ufw set errors 'Could not load logging rules', disable then enable logging once set
 
-    sleep 2
-    sudo ufw --force enable >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
-    sleep 2
+    FIREWALL_RULES=$(sudo ufw status verbose | grep -c -e active -e "allow (outgoing)" -e "allow (routed)" -e 22 -e cni0)
 
-    sleep 2
-    sudo ufw logging off >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
-    sleep 2
+    if [ $FIREWALL_RULES -lt 8 ]; then
 
-    sleep 2
-    sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
-    sleep 2
+        echo printf "\nConfiguring default firewall rules...\n"
 
-    sleep 2
-    sudo ufw default allow routed >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
-    sleep 2
+        sleep 2
+        sudo ufw --force enable >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
+        sleep 10
 
-    sleep 2
-    sudo ufw default allow outgoing >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
-    sleep 2
+        sleep 2
+        sudo ufw logging off >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
+        sleep 5
 
-    sleep 2
-    sudo ufw allow in on cni0 >>$LOG_FILE 2>&1 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
-    sleep 2
+        sleep 2
+        sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
+        sleep 2
+
+        sleep 2
+        sudo ufw default allow routed >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
+        sleep 10
+
+        sleep 2
+        sudo ufw default allow outgoing >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
+        sleep 10
+
+        sleep 2
+        sudo ufw allow in on cni0 >>$LOG_FILE 2>&1 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
+        sleep 2
+
+        sleep 2
+        sudo ufw logging off >>$LOG_FILE 2>&1
+        errchk $? "sudo ufw logging on >> $LOG_FILE 2>&1"
+        sleep 5
+
+    else
+
+        echo printf "\Default firewall rules already configured...\n"
+
+    fi
 
     # Wait for system to stabilize and avoid race conditions
+
     sleep 10
 
     initialize_microk8s

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -560,12 +560,8 @@ offer_nodes_upgrade() {
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
 	
-	MICROK8S_INSTALLED=$(dpkg-query --list | grep -i "microk8s")
-	if [ $MICROK8S_INSTALLED -eq 0 ]; then
-	
-	prompt_node_name
-	
-	fi
+	MICROK8S_INSTALLED=$(dpkg-query -W -f='${Status}' microk8s)
+	if [ $MICROK8S_INSTALLED ]; then
 	
     DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")
 
@@ -610,6 +606,10 @@ offer_nodes_upgrade() {
         fi
 
     fi
+	
+prompt_node_name	
+
+fi
 }
 
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -275,7 +275,7 @@ bootstrap_environment() {
 
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
-    sudo ufw --force enable -w >>$LOG_FILE 2>&1
+    sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
 
     sudo ufw allow 22/tcp -w >>$LOG_FILE 2>&1

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -527,8 +527,6 @@ check_matchmaking_status() {
 
         check_matchmaking_status
 
-        done
-
         exit 0
 
         fi

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -336,7 +336,7 @@ check_existing_install() {
         while [[ "$ANSWER" != "d" && "$ANSWER" != "delete" && "$ANSWER" != "u" && "$ANSWER" != "upgrade" ]]; do
             echo -e "\e[2mIf you would like to upgrade node $DRAGONCHAIN_INSTALLER_DIR, press \e[93m[u]\e[0m"
             echo -e "\e[2mIf you would like to delete a failed or incorrect installation for node $DRAGONCHAIN_INSTALLER_DIR, press \e[93m[d]\e[0m"
-            echo -e "\e[91m(All configuration for $DRAGONCHAIN_INSTALLER_DIR will be deleted. Other running nodes will be unaffected)\e[0m"
+            echo -e "\e[91m(If you delete, all configuration for $DRAGONCHAIN_INSTALLER_DIR will be removed. Other running nodes will be unaffected)\e[0m"
             read ANSWER
             echo
         done
@@ -607,8 +607,8 @@ offer_nodes_upgrade() {
     if [ $DC_PODS_EXIST -ge 1 ]; then
         local ANSWER=""
         while [[ "$ANSWER" != "i" && "$ANSWER" != "install" && "$ANSWER" != "u" && "$ANSWER" != "upgrade" ]]; do
-            echo -e "\n\e[93mPre-existing Dragonchain nodes have been detected.\e[0m"
-            echo -e "\e[2mIf you would like to install a new node (including upgrading, repairing or deleting existing nodes), press \e[93m[i]\e[0m"
+            echo -e "\n\n\e[93mPre-existing Dragonchain nodes have been detected.\e[0m"
+            echo -e "\e[2mIf you would like to install a new node (including upgrading, repairing or deleting specific nodes), press \e[93m[i]\e[0m"
             echo -e "\e[2mIf you would like to upgrade ALL detected nodes to the latest version, press \e[93m[u]\e[0m"
             read ANSWER
             echo
@@ -650,7 +650,7 @@ offer_nodes_upgrade() {
 
 ## Main()
 
-echo -e "\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
+echo -e "\n\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
 
 #patch system current
 printf "\nUpdating (patching) host OS current...\n"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -312,7 +312,7 @@ bootstrap_environment() {
         sleep 5
 
         sleep 2
-        sudo ufw logging off >>$LOG_FILE 2>&1
+        sudo ufw logging on >>$LOG_FILE 2>&1
         errchk $? "sudo ufw logging on >> $LOG_FILE 2>&1"
         sleep 5
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -53,13 +53,6 @@ prompt_node_name() {
 
     read -e DRAGONCHAIN_INSTALLER_DIR
 
-    local PI=""
-    while [[ "$PI" != "y" && "$PI" != "yes" && "$PI" != "n" && "$PI" != "no" ]]; do
-        echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no]\e[0m"
-        read PI
-        echo
-    done
-
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
 }
@@ -436,13 +429,16 @@ install_dragonchain() {
     sudo helm repo update >>$LOG_FILE 2>&1
     errchk $? "sudo helm repo update >> $LOG_FILE 2>&1"
 
-    if [[ "$PI" == "y" || "$PI" == "yes" ]]; then
-        # User is running Raspberry Pi
+    RASPBERRY_PI=$(sudo ufw status verbose | grep -c -e active -e "allow (outgoing)" -e "allow (routed)" -e 22 -e cni0)
+
+    if [ $RASPBERRY_PI -eq 1 ]; then
+
+        # Running Raspberry Pi
         # Deploy Helm Chart
         #
         # Set CPU limits
 
-        printf "\Installing Dragonchain configuration for Raspberry Pi...\n"
+        printf "\nInstalling Dragonchain for Raspberry Pi...\n"
 
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
@@ -460,11 +456,11 @@ install_dragonchain() {
 
     else
 
-        # User is not running Raspberry Pi
+        # Not Running Raspberry Pi
         # Deploy Helm Chart
         #
 
-        printf "\Installing Dragonchain...\n"
+        printf "\nInstalling Dragonchain...\n"
 
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -391,6 +391,9 @@ check_existing_install() {
 
             sleep 5
 
+            echo -e "\nDeleting firewall configuration for '$DRAGONCHAIN_INSTALLER_DIR'..."
+            sudo sudo ufw delete allow $DRAGONCHAIN_UVN_NODE_PORT/tcp
+
             echo -e "\nConfiguration data for '$DRAGONCHAIN_INSTALLER_DIR' has been deleted and the node has been terminated."
             echo -e "Please rerun the installer to reconfigure this node."
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -434,8 +434,9 @@ install_dragonchain() {
         --set redis.storage.spec.storageClassName="microk8s-hostpath" \
         --set redisearch.storage.spec.storageClassName="microk8s-hostpath" \
         --set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
-        fi
-
+        
+		
+		else
         # User is not running Raspberry Pi
         # Deploy Helm Chart
         #

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -559,11 +559,8 @@ offer_nodes_upgrade() {
 
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
-	
-	MICROK8S_INSTALLED=$(dpkg-query -W -f='${Status}' microk8s)
-	if [ $MICROK8S_INSTALLED ]; then
-	
-    DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")
+
+    DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")>/dev/null 2>&1
 
     if [ $DC_PODS_EXIST -ge 1 ]; then
         local ANSWER=""
@@ -606,10 +603,6 @@ offer_nodes_upgrade() {
         fi
 
     fi
-	else echo -e "bum"
-prompt_node_name	
-
-fi
 }
 
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -559,8 +559,16 @@ offer_nodes_upgrade() {
 
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
+    
+    MICROK8S_INSTALLED=$(sudo snap list | grep "microk8s")
+    
+    if ! [ MICROK8S_INSTALLED ]; then
 
-    DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")>/dev/null 2>&1
+        prompt_node_name
+
+    fi
+    
+    DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")
 
     if [ $DC_PODS_EXIST -ge 1 ]; then
         local ANSWER=""

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -341,7 +341,7 @@ bootstrap_environment() {
 ## Function initialize_microk8s
 initialize_microk8s() {
 
-    printf "\nCreating Containers...\n"
+    printf "\nInitializing microk8s...\n"
 
     # Enable Microk8s modules
     # unable to errchk this command because microk8s.enable helm command will RC=2 b/c nothing for helm to do
@@ -440,7 +440,10 @@ install_dragonchain() {
         # User is running Raspberry Pi
         # Deploy Helm Chart
         #
-        # Set CPU limits 
+        # Set CPU limits
+
+        printf "\Installing Dragonchain configuration for Raspberry Pi...\n"
+
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
         --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \
@@ -460,6 +463,9 @@ install_dragonchain() {
         # User is not running Raspberry Pi
         # Deploy Helm Chart
         #
+
+        printf "\Installing Dragonchain...\n"
+
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
         --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -236,6 +236,9 @@ request_user_defined_values() {
 ##########################################################################
 ## Function patch_server_current
 patch_server_current() {
+
+    LOG_FILE=./dragonchain_uvn_installer_bootstrap.log
+
     #Patch our system current [stable]
     sudo apt-get update >>$LOG_FILE 2>&1
     errchk $? "sudo apt-get update >> $LOG_FILE 2>&1"
@@ -252,10 +255,7 @@ bootstrap_environment() {
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
 
     #duck note: might want to check the .conf file for this line to already exist before adding again
-
-    LOG_FILE=./dragonchain_uvn_installer_bootstrap.log
-    SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
-
+      
     echo "vm.max_map_count=262144" | sudo tee -a /etc/sysctl.conf >/dev/null
     sudo sysctl -w vm.max_map_count=262144 >>$LOG_FILE 2>&1
     errchk $? "sudo sysctl -w vm.max_map_count=262144 >> $LOG_FILE 2>&1"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -46,18 +46,16 @@ trim() {
 ##########################################################################
 ## Function prompt_node_name
 prompt_node_name() {
-echo -e "\n\e[94mEnter a Dragonchain node name:\e[0m"
-echo -e "\e[2mThe name must be unique if you intend to run multiple nodes\e[0m"
-echo -e "\e[2mThe name can contain numbers, lowercase characters and '-' ONLY\e[0m"
-echo -e "\e[2mTo upgrade, repair or delete a specific installation, type the node name of that installation\e[0m"
+    echo -e "\n\e[94mEnter a Dragonchain node name:\e[0m"
+    echo -e "\e[2mThe name must be unique if you intend to run multiple nodes\e[0m"
+    echo -e "\e[2mThe name can contain numbers, lowercase characters and '-' ONLY\e[0m"
+    echo -e "\e[2mTo upgrade, repair or delete a specific installation, type the node name of that installation\e[0m"
 
-read -e DRAGONCHAIN_INSTALLER_DIR
+    read -e DRAGONCHAIN_INSTALLER_DIR
 
-LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
-SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
+    LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
+    SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
 }
-
-
 
 ##########################################################################
 ## Function preflight_check
@@ -255,7 +253,7 @@ bootstrap_environment() {
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
 
     #duck note: might want to check the .conf file for this line to already exist before adding again
-      
+
     echo "vm.max_map_count=262144" | sudo tee -a /etc/sysctl.conf >/dev/null
     sudo sysctl -w vm.max_map_count=262144 >>$LOG_FILE 2>&1
     errchk $? "sudo sysctl -w vm.max_map_count=262144 >> $LOG_FILE 2>&1"
@@ -275,28 +273,28 @@ bootstrap_environment() {
 
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
-    #duck To stop ufw errors 'Could not load logging rules', disable logging 
-       
+    #duck To stop ufw errors 'Could not load logging rules', disable logging
+
     sleep 2
     sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
     sleep 2
 
-    sleep 2   
+    sleep 2
     sudo ufw logging off >>$LOG_FILE 2>&1
     errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
     sleep 2
-    
+
     sleep 2
     sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
     sleep 2
-    
+
     sleep 2
     sudo ufw default allow routed >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
     sleep 2
-    
+
     sleep 2
     sudo ufw default allow outgoing >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
@@ -410,14 +408,14 @@ install_dragonchain() {
     sudo helm repo update >>$LOG_FILE 2>&1
     errchk $? "sudo helm repo update >> $LOG_FILE 2>&1"
 
-       local ANSWER=""
-        while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]; do
-            echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no].\e[0m"
-            read ANSWER
-            echo
-        done
+    local ANSWER=""
+    while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]; do
+        echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no].\e[0m"
+        read ANSWER
+        echo
+    done
 
-        if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]; then
+    if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]; then
         # User is running Raspberry Pi
         # Deploy Helm Chart
         #
@@ -433,10 +431,10 @@ install_dragonchain() {
         --set dragonchain.storage.spec.storageClassName="microk8s-hostpath" \
         --set redis.storage.spec.storageClassName="microk8s-hostpath" \
         --set redisearch.storage.spec.storageClassName="microk8s-hostpath" \
-        --set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
-        
-		
-		else
+        --set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >>$LOG_FILE 2>&1
+
+    else
+
         # User is not running Raspberry Pi
         # Deploy Helm Chart
         #
@@ -454,7 +452,7 @@ install_dragonchain() {
         --set redisearch.storage.spec.storageClassName="microk8s-hostpath" >>$LOG_FILE 2>&1
         #--set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
 
-    errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"       
+        errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"
 
     fi
 
@@ -544,36 +542,36 @@ check_matchmaking_status() {
 
         if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]; then
 
-        ## Prompt for Dragonchain node name
-        prompt_node_name
+            ## Prompt for Dragonchain node name
+            prompt_node_name
 
-        #check for required commands, setup logging
-        preflight_check
+            #check for required commands, setup logging
+            preflight_check
 
-        #load config values or gather from user
-        set_config_values
+            #load config values or gather from user
+            set_config_values
 
-        # check for previous installation (failed or successful) and offer reset if found
-        printf "\nChecking for previous installation...\n"
-        check_existing_install
+            # check for previous installation (failed or successful) and offer reset if found
+            printf "\nChecking for previous installation...\n"
+            check_existing_install
 
-        # must gather node details from user or .config before generating chainsecrets
-        printf "\nGenerating chain secrets...\n"
-        generate_chainsecrets
+            # must gather node details from user or .config before generating chainsecrets
+            printf "\nGenerating chain secrets...\n"
+            generate_chainsecrets
 
-        printf "\nInstalling UVN Dragonchain - $DRAGONCHAIN_INSTALLER_DIR...\n"
-        install_dragonchain
+            printf "\nInstalling UVN Dragonchain - $DRAGONCHAIN_INSTALLER_DIR...\n"
+            install_dragonchain
 
-        check_kube_status
+            check_kube_status
 
-        set_dragonchain_public_id
+            set_dragonchain_public_id
 
-        check_matchmaking_status
+            check_matchmaking_status
 
-        exit 0
+            exit 0
 
         fi
-    
+
     else
         #Boo!
         echo -e "\e[31mYOUR DRAGONCHAIN NODE '$DRAGONCHAIN_INSTALLER_DIR' IS ONLINE BUT THE MATCHMAKING API RETURNED AN ERROR. PLEASE SEE BELOW AND REQUEST HELP IN DRAGONCHAIN TELEGRAM\e[0m"
@@ -644,7 +642,7 @@ offer_nodes_upgrade() {
 
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
-    
+
     DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")
 
     if [ $DC_PODS_EXIST -ge 1 ]; then
@@ -689,7 +687,6 @@ offer_nodes_upgrade() {
 
     fi
 }
-
 
 ## Main()
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -275,6 +275,11 @@ bootstrap_environment() {
 
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
+    #duck To stop ufw errors 'Could not load logging rules', disable logging 
+    sudo ufw ufw logging off >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
+    sleep 5
+
     sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
     sleep 5

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -677,6 +677,12 @@ offer_nodes_upgrade() {
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
 
+    sudo helm repo add dragonchain https://dragonchain-charts.s3.amazonaws.com >>$LOG_FILE 2>&1
+    errchk $? "sudo helm repo add dragonchain https://dragonchain-charts.s3.amazonaws.com >> $LOG_FILE 2>&1"
+
+    sudo helm repo update >>$LOG_FILE 2>&1
+    errchk $? "sudo helm repo update >> $LOG_FILE 2>&1"
+    
     DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")
 
     if [ $DC_PODS_EXIST -ge 1 ]; then

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -294,7 +294,7 @@ bootstrap_environment() {
         sleep 2
         sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
         errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
-        sleep 2
+        sleep 5
 
         sleep 2
         sudo ufw default allow routed >>$LOG_FILE 2>&1
@@ -309,7 +309,7 @@ bootstrap_environment() {
         sleep 2
         sudo ufw allow in on cni0 >>$LOG_FILE 2>&1 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
         errchk $? "sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
-        sleep 2
+        sleep 5
 
         sleep 2
         sudo ufw logging off >>$LOG_FILE 2>&1

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -216,6 +216,7 @@ request_user_defined_values() {
     done
 
     #duck Moved node port firewall rule here in order to run bootstrap before this parameter is created
+    sleep 2
     sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >> $LOG_FILE 2>&1"
     sleep 2
@@ -276,29 +277,36 @@ bootstrap_environment() {
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
     #duck To stop ufw errors 'Could not load logging rules', disable logging 
+     
+    sleep 2   
     sudo ufw logging off >>$LOG_FILE 2>&1
     errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
-    sleep 5
-
+    sleep 2
+    
+    sleep 2
     sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
-    sleep 5
-
+    sleep 2
+    
+    sleep 2
     sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
-    sleep 5
-
-    sudo ufw default allow routed -w >>$LOG_FILE 2>&1
+    sleep 2
+    
+    sleep 2
+    sudo ufw default allow routed >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
-    sleep 5
-
-    sudo ufw default allow outgoing -w >>$LOG_FILE 2>&1
+    sleep 2
+    
+    sleep 2
+    sudo ufw default allow outgoing >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
-    sleep 5
+    sleep 2
 
+    sleep 2
     sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
-    sleep 5
+    sleep 2
 
     # Wait for system to stabilize and avoid race conditions
     sleep 10

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -275,7 +275,7 @@ bootstrap_environment() {
     # This should be reviewed - confident we can restrict this further
     #duck To stop ufw set errors 'Could not load logging rules', disable then enable logging once set
 
-    FIREWALL_RULES=$(sudo ufw status verbose | grep -c -e active -e "allow (outgoing)" -e "allow (routed)" -e 22 -e cni0)
+    FIREWALL_RULES=$(sudo ufw status verbose | grep -c -e active -e "(^|\s)'allow (outgoing)'(\s|$)" -e "(^|\s)'allow (routed)'(\s|$)" -e 22 -e cni0)
 
     if [ $FIREWALL_RULES -lt 8 ]; then
 
@@ -369,7 +369,7 @@ check_existing_install() {
     NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -c -E "(^|\s)$DRAGONCHAIN_INSTALLER_DIR(\s|$)")
 
     if [ $NAMESPACE_EXISTS -ge 1 ]; then
-        echo -e "\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"
+        echo -e "\n\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"
 
         local ANSWER=""
         while [[ "$ANSWER" != "d" && "$ANSWER" != "delete" && "$ANSWER" != "u" && "$ANSWER" != "upgrade" ]]; do
@@ -394,8 +394,8 @@ check_existing_install() {
             echo -e "\nDeleting firewall configuration for '$DRAGONCHAIN_INSTALLER_DIR'..."
             sudo sudo ufw delete allow $DRAGONCHAIN_UVN_NODE_PORT/tcp
 
-            echo -e "\nConfiguration data for '$DRAGONCHAIN_INSTALLER_DIR' has been deleted and the node has been terminated."
-            echo -e "Please rerun the installer to reconfigure this node."
+            echo -e "\n\e[93mConfiguration data for '$DRAGONCHAIN_INSTALLER_DIR' has been deleted and the node has been terminated.\e[0m"
+            echo -e "\e[93mPlease rerun the installer to reconfigure this node.\e[0m"
 
             exit 0
         fi

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -276,27 +276,22 @@ bootstrap_environment() {
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
     sudo ufw --force enable >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
-    sleep 2
+    errchk $? "sudo ufw --force enable -w >> $LOG_FILE 2>&1"
 
     sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
-    sleep 2
+    errchk $? "sudo ufw allow 22/tcp -w >> $LOG_FILE 2>&1"
 
     sudo ufw default allow routed >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
-    sleep 2
+    errchk $? "sudo ufw default allow routed -w >> $LOG_FILE 2>&1"
 
     sudo ufw default allow outgoing >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
-    sleep 2
+    errchk $? "sudo ufw default allow outgoing -w >> $LOG_FILE 2>&1"
 
     sudo ufw allow in on cni0 >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow in on cni0 >> $LOG_FILE 2>&1"
-    sleep 2
+    errchk $? "sudo ufw allow in on cni0 -w >> $LOG_FILE 2>&1"
 
     sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
+    errchk $? "sudo ufw allow out on cni0 -w >> $LOG_FILE 2>&1"
 
     # Wait for system to stabilize and avoid race conditions
     sleep 30

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -119,7 +119,7 @@ function set_config_values() {
         # Execute config file
         . $DRAGONCHAIN_INSTALLER_DIR/.config
 
-        echo -e "\e[93mSaved configuration values found:\e[0m"
+        echo -e "\n\e[93mSaved configuration values found:\e[0m"
         echo "Namespace = $DRAGONCHAIN_INSTALLER_DIR"
         echo "Name = $DRAGONCHAIN_UVN_NODE_NAME"
         echo "Chain ID = $DRAGONCHAIN_UVN_INTERNAL_ID"
@@ -163,7 +163,7 @@ request_user_defined_values() {
     # Collect user-configured fields
     # TODO: Sanitize all inputs
 
-    echo -e "\e[94mEnter your Chain ID from the Dragonchain console:\e[0m"
+    echo -e "\n\e[94mEnter your Chain ID from the Dragonchain console:\e[0m"
     read DRAGONCHAIN_UVN_INTERNAL_ID
     DRAGONCHAIN_UVN_INTERNAL_ID=$(echo $DRAGONCHAIN_UVN_INTERNAL_ID | tr -d '\r')
     echo
@@ -358,36 +358,36 @@ check_existing_install() {
     NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -c $DRAGONCHAIN_INSTALLER_DIR)
 
     if [ $NAMESPACE_EXISTS -ge 1 ]; then
-        echo -e "\e[93mA previous installation of Dragonchain node $DRAGONCHAIN_INSTALLER_DIR (failed or complete) was found.\e[0m"
+        echo -e "\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"
 
         local ANSWER=""
         while [[ "$ANSWER" != "d" && "$ANSWER" != "delete" && "$ANSWER" != "u" && "$ANSWER" != "upgrade" ]]; do
-            echo -e "\e[2mIf you would like to upgrade node $DRAGONCHAIN_INSTALLER_DIR, press \e[93m[u]\e[0m"
-            echo -e "\e[2mIf you would like to delete a failed or incorrect installation for node $DRAGONCHAIN_INSTALLER_DIR, press \e[93m[d]\e[0m"
-            echo -e "\e[91m(If you delete, all configuration for $DRAGONCHAIN_INSTALLER_DIR will be removed. Other running nodes will be unaffected)\e[0m"
+            echo -e "\e[2mIf you would like to upgrade node '$DRAGONCHAIN_INSTALLER_DIR', press \e[93m[u]\e[0m"
+            echo -e "\e[2mIf you would like to delete a failed or incorrect installation for node '$DRAGONCHAIN_INSTALLER_DIR', press \e[93m[d]\e[0m"
+            echo -e "\e[91m(If you delete, all configuration for '$DRAGONCHAIN_INSTALLER_DIR' will be removed. Other running nodes will be unaffected)\e[0m"
             read ANSWER
             echo
         done
 
         if [[ "$ANSWER" == "d" || "$ANSWER" == "delete" ]]; then
             # User wants to delete namespace
-            echo -e "Deleting node $DRAGONCHAIN_INSTALLER_DIR (may take several minutes)..."
+            echo -e "Deleting node '$DRAGONCHAIN_INSTALLER_DIR' (may take several minutes)..."
             sudo kubectl delete namespaces $DRAGONCHAIN_INSTALLER_DIR >>$LOG_FILE 2>&1
             errchk $? "sudo kubectl delete namespaces"
 
-            echo -e "\nDeleting saved configuration for $DRAGONCHAIN_INSTALLER_DIR..."
+            echo -e "\nDeleting saved configuration for '$DRAGONCHAIN_INSTALLER_DIR'..."
             sudo rm $DRAGONCHAIN_INSTALLER_DIR -R
 
             sleep 5
 
-            echo -e "\nConfiguration data for $DRAGONCHAIN_INSTALLER_DIR has been deleted and the node has been terminated."
+            echo -e "\nConfiguration data for '$DRAGONCHAIN_INSTALLER_DIR' has been deleted and the node has been terminated."
             echo -e "Please rerun the installer to reconfigure this node."
 
             exit 0
         fi
 
         # User wants to attempt upgrade
-        printf "\nUpgrading UVN Dragonchain - $DRAGONCHAIN_INSTALLER_DIR...\n"
+        printf "\nUpgrading UVN Dragonchain '$DRAGONCHAIN_INSTALLER_DIR'...\n"
 
         install_dragonchain
 
@@ -438,7 +438,7 @@ install_dragonchain() {
         #
         # Set CPU limits
 
-        printf "\nInstalling Dragonchain for Raspberry Pi...\n"
+        printf "\nInstalling UVN Dragonchain '$DRAGONCHAIN_INSTALLER_DIR' for Raspberry Pi...\n"
 
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
@@ -460,7 +460,7 @@ install_dragonchain() {
         # Deploy Helm Chart
         #
 
-        printf "\nInstalling Dragonchain...\n"
+        printf "\nInstalling UVN Dragonchain '$DRAGONCHAIN_INSTALLER_DIR'...\n"
 
         sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
         --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
@@ -580,7 +580,6 @@ check_matchmaking_status() {
             printf "\nGenerating chain secrets...\n"
             generate_chainsecrets
 
-            printf "\nInstalling UVN Dragonchain - $DRAGONCHAIN_INSTALLER_DIR...\n"
             install_dragonchain
 
             check_kube_status
@@ -742,7 +741,6 @@ check_existing_install
 printf "\nGenerating chain secrets...\n"
 generate_chainsecrets
 
-printf "\nInstalling UVN Dragonchain - $DRAGONCHAIN_INSTALLER_DIR...\n"
 install_dragonchain
 
 check_kube_status

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -279,7 +279,7 @@ bootstrap_environment() {
 
     if [ $FIREWALL_RULES -lt 8 ]; then
 
-        echo printf "\nConfiguring default firewall rules...\n"
+        printf "\nConfiguring default firewall rules...\n"
 
         sleep 2
         sudo ufw --force enable >>$LOG_FILE 2>&1
@@ -318,7 +318,7 @@ bootstrap_environment() {
 
     else
 
-        echo printf "\Default firewall rules already configured...\n"
+        printf "Default firewall rules already configured. Continuing..."
 
     fi
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -645,7 +645,7 @@ offer_nodes_upgrade() {
 
 ## Main()
 
-echo -e "\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
+echo -e "\n\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
 
 #patch system current
 printf "\nUpdating (patching) host OS current...\n"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -281,7 +281,7 @@ bootstrap_environment() {
 
         printf "\nConfiguring default firewall rules...\n"
 
-        sleep 2
+        sleep 10
         sudo ufw --force enable >>$LOG_FILE 2>&1
         errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
         sleep 10

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -275,7 +275,7 @@ bootstrap_environment() {
     # This should be reviewed - confident we can restrict this further
     #duck To stop ufw set errors 'Could not load logging rules', disable then enable logging once set
 
-    FIREWALL_RULES=$(sudo ufw status verbose | grep -c -e active -e "(^|\s)'allow (outgoing)'(\s|$)" -e "(^|\s)'allow (routed)'(\s|$)" -e 22 -e cni0)
+    FIREWALL_RULES=$(sudo ufw status verbose | grep -c -Fwf <(printf "%s\n" active 'allow (routed)' 22 cni0))
 
     if [ $FIREWALL_RULES -lt 8 ]; then
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -281,7 +281,7 @@ bootstrap_environment() {
 
         printf "\nConfiguring default firewall rules...\n"
 
-        sleep 10
+        sleep 20
         sudo ufw --force enable >>$LOG_FILE 2>&1
         errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
         sleep 10

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -298,7 +298,7 @@ bootstrap_environment() {
     sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
     sleep 5
-    
+
     # Wait for system to stabilize and avoid race conditions
     sleep 10
 
@@ -669,7 +669,6 @@ offer_nodes_upgrade
 prompt_node_name
 
 #check for required commands, setup logging
-printf "\n\nChecking host OS for necessary components...\n\n"
 preflight_check
 
 #load config values or gather from user

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -410,23 +410,53 @@ install_dragonchain() {
     sudo helm repo update >>$LOG_FILE 2>&1
     errchk $? "sudo helm repo update >> $LOG_FILE 2>&1"
 
-    # Deploy Helm Chart
-    #
-    # For Raspberry Pi installations, uncomment the last --set line and
-    # on the --set redis.storage.spec.storageClassName line above it, replace >> $LOG_FILE 2>&1 with \
-    sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
-    --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
-    --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \
-    --set global.environment.INTERNAL_ID="$DRAGONCHAIN_UVN_INTERNAL_ID" \
-    --set global.environment.DRAGONCHAIN_ENDPOINT="$DRAGONCHAIN_UVN_ENDPOINT_URL:$DRAGONCHAIN_UVN_NODE_PORT" \
-    --set-string global.environment.LEVEL=$DRAGONCHAIN_UVN_NODE_LEVEL \
-    --set service.port=$DRAGONCHAIN_UVN_NODE_PORT \
-    --set dragonchain.storage.spec.storageClassName="microk8s-hostpath" \
-    --set redis.storage.spec.storageClassName="microk8s-hostpath" \
-    --set redisearch.storage.spec.storageClassName="microk8s-hostpath" >>$LOG_FILE 2>&1
-    #--set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
+       local ANSWER=""
+        while [[ "$ANSWER" != "y" && "$ANSWER" != "yes" && "$ANSWER" != "n" && "$ANSWER" != "no" ]]; do
+            echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no].\e[0m"
+            read ANSWER
+            echo
+        done
 
-    errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"
+        if [[ "$ANSWER" == "y" || "$ANSWER" == "yes" ]]; then
+        # User is running Raspberry Pi
+        # Deploy Helm Chart
+        #
+        # For Raspberry Pi installations, uncomment the last --set line and
+        # on the --set redis.storage.spec.storageClassName line above it, replace >> $LOG_FILE 2>&1 with \
+        sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
+        --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
+        --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \
+        --set global.environment.INTERNAL_ID="$DRAGONCHAIN_UVN_INTERNAL_ID" \
+        --set global.environment.DRAGONCHAIN_ENDPOINT="$DRAGONCHAIN_UVN_ENDPOINT_URL:$DRAGONCHAIN_UVN_NODE_PORT" \
+        --set-string global.environment.LEVEL=$DRAGONCHAIN_UVN_NODE_LEVEL \
+        --set service.port=$DRAGONCHAIN_UVN_NODE_PORT \
+        --set dragonchain.storage.spec.storageClassName="microk8s-hostpath" \
+        --set redis.storage.spec.storageClassName="microk8s-hostpath" \
+        --set redisearch.storage.spec.storageClassName="microk8s-hostpath" \
+        --set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
+        fi
+
+        # User is not running Raspberry Pi
+        # Deploy Helm Chart
+        #
+        # For Raspberry Pi installations, uncomment the last --set line and
+        # on the --set redis.storage.spec.storageClassName line above it, replace >> $LOG_FILE 2>&1 with \
+        sudo helm upgrade --install $DRAGONCHAIN_UVN_NODE_NAME --namespace $DRAGONCHAIN_INSTALLER_DIR dragonchain/dragonchain-k8s \
+        --set global.environment.DRAGONCHAIN_NAME="$DRAGONCHAIN_UVN_NODE_NAME" \
+        --set global.environment.REGISTRATION_TOKEN="$DRAGONCHAIN_UVN_REGISTRATION_TOKEN" \
+        --set global.environment.INTERNAL_ID="$DRAGONCHAIN_UVN_INTERNAL_ID" \
+        --set global.environment.DRAGONCHAIN_ENDPOINT="$DRAGONCHAIN_UVN_ENDPOINT_URL:$DRAGONCHAIN_UVN_NODE_PORT" \
+        --set-string global.environment.LEVEL=$DRAGONCHAIN_UVN_NODE_LEVEL \
+        --set service.port=$DRAGONCHAIN_UVN_NODE_PORT \
+        --set dragonchain.storage.spec.storageClassName="microk8s-hostpath" \
+        --set redis.storage.spec.storageClassName="microk8s-hostpath" \
+        --set redisearch.storage.spec.storageClassName="microk8s-hostpath" >>$LOG_FILE 2>&1
+        #--set cacheredis.resources.limits.cpu=1,persistentredis.resources.limits.cpu=1,webserver.resources.limits.cpu=2,transactionProcessor.resources.limits.cpu=1 >> $LOG_FILE 2>&1
+
+    errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"       
+
+    fi
+
 }
 
 ##########################################################################

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -299,12 +299,12 @@ bootstrap_environment() {
         sleep 2
         sudo ufw default allow routed >>$LOG_FILE 2>&1
         errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
-        sleep 10
+        sleep 15
 
         sleep 2
         sudo ufw default allow outgoing >>$LOG_FILE 2>&1
         errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
-        sleep 10
+        sleep 15
 
         sleep 2
         sudo ufw allow in on cni0 >>$LOG_FILE 2>&1 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -334,22 +334,33 @@ bootstrap_environment() {
 ## Function initialize_microk8s
 initialize_microk8s() {
 
-    printf "\nInitializing microk8s...\n"
+    MICROK8S_INITIALIZED=$(sudo kubectl get namespaces | grep -c -e container-registry -e kube-system)
 
-    # Enable Microk8s modules
-    # unable to errchk this command because microk8s.enable helm command will RC=2 b/c nothing for helm to do
-    sudo microk8s.enable dns storage helm3 >>$LOG_FILE 2>&1
+    if [ $MICROK8S_INITIALIZED -lt 2 ]; then
 
-    # Alias helm3
-    sudo snap alias microk8s.helm3 helm >>$LOG_FILE 2>&1
-    errchk $? "sudo snap alias microk8s.helm3 helm >> $LOG_FILE 2>&1"
+        printf "\nInitializing microk8s...\n"
 
-    # Wait for system to stabilize and avoid race conditions
-    sleep 10
+        # Enable Microk8s modules
+        # unable to errchk this command because microk8s.enable helm command will RC=2 b/c nothing for helm to do
+        sudo microk8s.enable dns storage helm3 >>$LOG_FILE 2>&1
 
-    # Install more Microk8s modules
-    sudo microk8s.enable registry >>$LOG_FILE 2>&1
-    errchk $? "sudo microk8s.enable registry >> $LOG_FILE 2>&1"
+        # Alias helm3
+        sudo snap alias microk8s.helm3 helm >>$LOG_FILE 2>&1
+        errchk $? "sudo snap alias microk8s.helm3 helm >> $LOG_FILE 2>&1"
+
+        # Wait for system to stabilize and avoid race conditions
+        sleep 10
+
+        # Install more Microk8s modules
+        sudo microk8s.enable registry >>$LOG_FILE 2>&1
+        errchk $? "sudo microk8s.enable registry >> $LOG_FILE 2>&1"
+
+    else
+
+        printf "\nmicrok8s initialized...\n"
+
+    fi
+    
 }
 
 ##########################################################################

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -360,13 +360,13 @@ initialize_microk8s() {
         printf "\nmicrok8s initialized...\n"
 
     fi
-    
+
 }
 
 ##########################################################################
 ## Function check_existing_install
 check_existing_install() {
-    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -w $DRAGONCHAIN_INSTALLER_DIR | grep -c $DRAGONCHAIN_INSTALLER_DIR)
+    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -c -E "(^|\s)$DRAGONCHAIN_INSTALLER_DIR(\s|$))
 
     if [ $NAMESPACE_EXISTS -ge 1 ]; then
         echo -e "\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -277,23 +277,28 @@ bootstrap_environment() {
     # This should be reviewed - confident we can restrict this further
     sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
-    sleep 10
+    sleep 5
 
     sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
+    sleep 5
 
     sudo ufw default allow routed >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
+    sleep 5
 
     sudo ufw default allow outgoing >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
+    sleep 5
 
     sudo ufw allow in on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow in on cni0 >> $LOG_FILE 2>&1"
+    sleep 5
 
     sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
-
+    sleep 5
+    
     # Wait for system to stabilize and avoid race conditions
     sleep 10
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -212,7 +212,6 @@ request_user_defined_values() {
         echo -e "\e[94mEnter the node level for your Dragonchain node (must be between 2 and 4):\e[0m"
         read DRAGONCHAIN_UVN_NODE_LEVEL
         DRAGONCHAIN_UVN_NODE_LEVEL=$(echo $DRAGONCHAIN_UVN_NODE_LEVEL | tr -d '\r')
-        echo
     done
 
     #duck Moved node port firewall rule here in order to run bootstrap before this parameter is created

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -333,6 +333,9 @@ bootstrap_environment() {
 ##########################################################################
 ## Function initialize_microk8s
 initialize_microk8s() {
+
+    printf "Creating Containers..."
+
     # Enable Microk8s modules
     # unable to errchk this command because microk8s.enable helm command will RC=2 b/c nothing for helm to do
     sudo microk8s.enable dns storage helm3 >>$LOG_FILE 2>&1

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -366,7 +366,7 @@ initialize_microk8s() {
 ##########################################################################
 ## Function check_existing_install
 check_existing_install() {
-    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -c -E "(^|\s)$DRAGONCHAIN_INSTALLER_DIR(\s|$))
+    NAMESPACE_EXISTS=$(sudo kubectl get namespaces | grep -c -E "(^|\s)$DRAGONCHAIN_INSTALLER_DIR(\s|$)")
 
     if [ $NAMESPACE_EXISTS -ge 1 ]; then
         echo -e "\e[93mA previous installation of Dragonchain node '$DRAGONCHAIN_INSTALLER_DIR' (failed or complete) was found.\e[0m"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -215,6 +215,11 @@ request_user_defined_values() {
         echo
     done
 
+    #duck Moved node port firewall rule here in order to run bootstrap before this parameter is created
+    sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >> $LOG_FILE 2>&1"
+    sleep 2
+
     # Write a fresh config file with user-defined values
     rm -f $DRAGONCHAIN_INSTALLER_DIR/.config
     touch $DRAGONCHAIN_INSTALLER_DIR/.config
@@ -247,6 +252,9 @@ bootstrap_environment() {
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
 
     #duck note: might want to check the .conf file for this line to already exist before adding again
+
+    LOG_FILE=./dragonchain_uvn_installer_bootstrap.log
+    SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
 
     echo "vm.max_map_count=262144" | sudo tee -a /etc/sysctl.conf >/dev/null
     sudo sysctl -w vm.max_map_count=262144 >>$LOG_FILE 2>&1
@@ -281,10 +289,6 @@ bootstrap_environment() {
 
     sudo ufw default allow outgoing >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
-    sleep 2
-
-    sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >> $LOG_FILE 2>&1"
     sleep 2
 
     sudo ufw allow in on cni0 >>$LOG_FILE 2>&1

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -284,7 +284,7 @@ bootstrap_environment() {
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw allow 22/tcp -w >>$LOG_FILE 2>&1
+    sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
     sleep 5
 
@@ -296,12 +296,8 @@ bootstrap_environment() {
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw allow in on cni0 -w >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow in on cni0 >> $LOG_FILE 2>&1"
-    sleep 5
-
-    sudo ufw allow out on cni0 -w >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
+    sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw allow in on cni0 && sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
     sleep 5
 
     # Wait for system to stabilize and avoid race conditions

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -645,7 +645,7 @@ offer_nodes_upgrade() {
 
 ## Main()
 
-echo -e "\n\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
+echo -e "\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
 
 #patch system current
 printf "\nUpdating (patching) host OS current...\n"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -277,15 +277,15 @@ bootstrap_environment() {
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
     #duck To stop ufw errors 'Could not load logging rules', disable logging 
-     
-    sleep 2   
-    sudo ufw logging off >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
-    sleep 2
-    
+       
     sleep 2
     sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
+    sleep 2
+
+    sleep 2   
+    sudo ufw logging off >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw logging off >> $LOG_FILE 2>&1"
     sleep 2
     
     sleep 2

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -508,6 +508,9 @@ check_matchmaking_status() {
         ## Prompt for Dragonchain node name
         prompt_node_name
 
+        #check for required commands, setup logging
+        preflight_check
+
         #load config values or gather from user
         set_config_values
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -429,7 +429,7 @@ install_dragonchain() {
     sudo helm repo update >>$LOG_FILE 2>&1
     errchk $? "sudo helm repo update >> $LOG_FILE 2>&1"
 
-    RASPBERRY_PI=$(sudo ufw status verbose | grep -c -e active -e "allow (outgoing)" -e "allow (routed)" -e 22 -e cni0)
+    RASPBERRY_PI=$(sudo lshw | grep -c "Raspberry")
 
     if [ $RASPBERRY_PI -eq 1 ]; then
 
@@ -472,7 +472,7 @@ install_dragonchain() {
         --set dragonchain.storage.spec.storageClassName="microk8s-hostpath" \
         --set redis.storage.spec.storageClassName="microk8s-hostpath" \
         --set redisearch.storage.spec.storageClassName="microk8s-hostpath" >>$LOG_FILE 2>&1
-        
+
         errchk $? "Dragonchain install command >> $LOG_FILE 2>&1"
 
     fi

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -318,7 +318,7 @@ bootstrap_environment() {
 
     else
 
-        printf "Default firewall rules already configured. Continuing..."
+        printf "\nDefault firewall rules already configured. Continuing...\n"
 
     fi
 
@@ -334,7 +334,7 @@ bootstrap_environment() {
 ## Function initialize_microk8s
 initialize_microk8s() {
 
-    printf "Creating Containers..."
+    printf "\nCreating Containers...\n"
 
     # Enable Microk8s modules
     # unable to errchk this command because microk8s.enable helm command will RC=2 b/c nothing for helm to do

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -216,7 +216,7 @@ request_user_defined_values() {
     done
 
     #duck Moved node port firewall rule here in order to run bootstrap before this parameter is created
-    sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >>$LOG_FILE 2>&1
+    sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow $DRAGONCHAIN_UVN_NODE_PORT/tcp >> $LOG_FILE 2>&1"
     sleep 2
 
@@ -284,23 +284,23 @@ bootstrap_environment() {
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
+    sudo ufw allow 22/tcp -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw default allow routed >>$LOG_FILE 2>&1
+    sudo ufw default allow routed -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw default allow outgoing >>$LOG_FILE 2>&1
+    sudo ufw default allow outgoing -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw allow in on cni0 >>$LOG_FILE 2>&1
+    sudo ufw allow in on cni0 -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow in on cni0 >> $LOG_FILE 2>&1"
     sleep 5
 
-    sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
+    sudo ufw allow out on cni0 -w >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
     sleep 5
 

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -606,7 +606,7 @@ offer_nodes_upgrade() {
         fi
 
     fi
-	
+	else echo -e "bum"
 prompt_node_name	
 
 fi

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -275,23 +275,23 @@ bootstrap_environment() {
 
     # Setup firewall rules
     # This should be reviewed - confident we can restrict this further
-    sudo ufw --force enable >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw --force enable -w >> $LOG_FILE 2>&1"
+    sudo ufw --force enable -w >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
 
-    sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow 22/tcp -w >> $LOG_FILE 2>&1"
+    sudo ufw allow 22/tcp -w >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
 
-    sudo ufw default allow routed >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw default allow routed -w >> $LOG_FILE 2>&1"
+    sudo ufw default allow routed -w >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
 
-    sudo ufw default allow outgoing >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw default allow outgoing -w >> $LOG_FILE 2>&1"
+    sudo ufw default allow outgoing -w >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
 
-    sudo ufw allow in on cni0 >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow in on cni0 -w >> $LOG_FILE 2>&1"
+    sudo ufw allow in on cni0 -w >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw allow in on cni0 >> $LOG_FILE 2>&1"
 
-    sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
-    errchk $? "sudo ufw allow out on cni0 -w >> $LOG_FILE 2>&1"
+    sudo ufw allow out on cni0 -w >>$LOG_FILE 2>&1
+    errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
 
     # Wait for system to stabilize and avoid race conditions
     sleep 30

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -277,24 +277,25 @@ bootstrap_environment() {
     # This should be reviewed - confident we can restrict this further
     sudo ufw --force enable >>$LOG_FILE 2>&1
     errchk $? "sudo ufw --force enable >> $LOG_FILE 2>&1"
+    sleep 10
 
-    sudo ufw allow 22/tcp -w >>$LOG_FILE 2>&1
+    sudo ufw allow 22/tcp >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow 22/tcp >> $LOG_FILE 2>&1"
 
-    sudo ufw default allow routed -w >>$LOG_FILE 2>&1
+    sudo ufw default allow routed >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow routed >> $LOG_FILE 2>&1"
 
-    sudo ufw default allow outgoing -w >>$LOG_FILE 2>&1
+    sudo ufw default allow outgoing >>$LOG_FILE 2>&1
     errchk $? "sudo ufw default allow outgoing >> $LOG_FILE 2>&1"
 
-    sudo ufw allow in on cni0 -w >>$LOG_FILE 2>&1
+    sudo ufw allow in on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow in on cni0 >> $LOG_FILE 2>&1"
 
-    sudo ufw allow out on cni0 -w >>$LOG_FILE 2>&1
+    sudo ufw allow out on cni0 >>$LOG_FILE 2>&1
     errchk $? "sudo ufw allow out on cni0 >> $LOG_FILE 2>&1"
 
     # Wait for system to stabilize and avoid race conditions
-    sleep 30
+    sleep 10
 
     initialize_microk8s
 
@@ -312,7 +313,7 @@ initialize_microk8s() {
     errchk $? "sudo snap alias microk8s.helm3 helm >> $LOG_FILE 2>&1"
 
     # Wait for system to stabilize and avoid race conditions
-    sleep 30
+    sleep 10
 
     # Install more Microk8s modules
     sudo microk8s.enable registry >>$LOG_FILE 2>&1

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -560,14 +560,6 @@ offer_nodes_upgrade() {
     LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.log
     SECURE_LOG_FILE=$DRAGONCHAIN_INSTALLER_DIR/dragonchain_uvn_installer.secure.log
     
-    MICROK8S_INSTALLED=$(sudo snap list | grep "microk8s")
-    
-    if ! [ MICROK8S_INSTALLED ]; then
-
-        prompt_node_name
-
-    fi
-    
     DC_PODS_EXIST=$(sudo kubectl get pods --all-namespaces | grep -c "dc-")
 
     if [ $DC_PODS_EXIST -ge 1 ]; then
@@ -618,7 +610,16 @@ offer_nodes_upgrade() {
 
 echo -e "\n\e[94mWelcome to the Dragonchain UVN Community Installer!\e[0m"
 
+#patch system current
+printf "\nUpdating (patching) host OS current...\n"
+patch_server_current
+
+#install necessary software, set tunables
+printf "\nInstalling required software and setting Dragonchain UVN system configuration...\n"
+bootstrap_environment
+
 ## Offer to upgrade all nodes
+printf "\nChecking for Pre-existing Dragonchain nodes to upgrade...\n"
 offer_nodes_upgrade
 
 ## Prompt for Dragonchain node name
@@ -630,14 +631,6 @@ preflight_check
 
 #load config values or gather from user
 set_config_values
-
-#patch system current
-printf "\nUpdating (patching) host OS current...\n"
-patch_server_current
-
-#install necessary software, set tunables
-printf "\nInstalling required software and setting Dragonchain UVN system configuration...\n"
-bootstrap_environment
 
 # check for previous installation (failed or successful) and offer reset if found
 printf "\nChecking for previous installation...\n"

--- a/install_dragonchain_uvn.sh
+++ b/install_dragonchain_uvn.sh
@@ -53,10 +53,10 @@ prompt_node_name() {
 
     read -e DRAGONCHAIN_INSTALLER_DIR
 
-    local ANSWER=""
+    local PI=""
     while [[ "$PI" != "y" && "$PI" != "yes" && "$PI" != "n" && "$PI" != "no" ]]; do
         echo -e "\n\e[93mAre you running on Raspberry Pi? [yes or no]\e[0m"
-        read ANSWER
+        read PI
         echo
     done
 


### PR DESCRIPTION
Improvements to Multi-node Installer:

- Moved Dragonchain port firewall rule into user_defined_values to allow the default firewall config to happen before we start to configure the node
- Can now skip default firewall rules at the start if we have already configured them
- With regard to ufw; still very picky about locks to iptables when running rules, especially after a new OS is installed so sleep time between rule creation increased to avoid race conditions/locks
- Skips microk8s initialization if we've already initialized
- Obtains hardware information and if we discover a Raspberry Pi will choose the amended helm --set command for CPU limits required by the Pi
- Prompts at the end of each installation to allow for another node install. Rinse and repeat!

Added Upgrade functionality:

- Detects pre-existing Dragonchains at startup and will offer an upgrade to all nodes (thanks to Alex B for the syntax!), prompt [u]. Else, prompt [i] to install a new node
- If typing a nodename that already exists, offers an upgrade prompt [u] for that specific node, or a delete [d] by 'sudo kubectl delete namespaces $namespace' for that node rather than a full microk8s reset as this is rarely required; plus we don't really want to be resetting all nodes in a multi-node environment. The delete option also removes saved configurations for the specified node in case of typos on the initial installation
- When deleting a node, the inbound port rule for that node will now also be deleted
